### PR TITLE
Improve Getting Started Docs for Local Node

### DIFF
--- a/validate-the-network/run-a-validator-full-node/getting-started.md
+++ b/validate-the-network/run-a-validator-full-node/getting-started.md
@@ -22,3 +22,35 @@ Any participant in the network can signal that they want to become a validator b
 After a validator is created, KII holders can delegate KII to them, effectively adding stake to the validator's pool. The total stake of an address is the combination of KII bonded by delegators and KII self-bonded by the validator.
 
 From all validator candidates that signaled themselves, the 100 validators with the most total stake are the designated **validators**. If a validator's total stake falls below the top 100, then that validator loses its validator privileges. The validator cannot participate in consensus or generate rewards until the stake is high enough to be in the top 100. Over time, the maximum number of validators may be increased via on-chain governance proposal.
+
+## Run a Local Full Node (For Development & Testing)
+
+You can simulate a KiiChain validator environment locally. This is useful for:
+
+- Testing validator commands
+- Understanding consensus flow
+- Experimenting without risking real funds
+
+### Prerequisites
+
+Make sure the following tools are installed:
+
+- [Go](https://go.dev/dl/) ≥ 1.21
+- Git
+- Make
+
+### Steps
+
+1. Clone the repo:
+
+   ```bash
+   git clone https://github.com/KiiChain/kiichain.git
+   cd kiichain
+   make install
+   kiid init my-local-node --chain-id kii-local
+   kiid keys add mykey
+   kiid add-genesis-account $(kiid keys show mykey -a) 1000000000ukii
+   kiid gentx mykey 700000000ukii --chain-id kii-local
+   kiid collect-gentxs
+   kiid start
+   ```


### PR DESCRIPTION
Improve getting-started.md by adding a full command block for running a local validator node, enabling easier testing and simulation for developers.

Previously, only partial steps were listed (make install). This update adds all the necessary CLI steps (init, keys, genesis, gentx, start) so developers can copy and run the full workflow without guesswork.