### PR TITLE
docs: add GitHub badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ description: >-
   onchain FX trading for cross-border payments.
 ---
 
+# KiiChain Documentation
+
+[![GitHub stars](https://img.shields.io/github/stars/KiiChain/kiichain-docs?style=social)](https://github.com/KiiChain/kiichain-docs/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/KiiChain/kiichain-docs?style=social)](https://github.com/KiiChain/kiichain-docs/network/members)
+[![GitHub issues](https://img.shields.io/github/issues/KiiChain/kiichain-docs)](https://github.com/KiiChain/kiichain-docs/issues)
+[![GitHub license](https://img.shields.io/github/license/KiiChain/kiichain-docs)](./LICENSE)
+
 # What is Kii?
 
 ### What is Kii
@@ -27,3 +34,4 @@ Kii has developed a suite of APIs that embed all centralized and decentralized f
 ### KYC / AML
 
 Kii complies fully with regulations in each jurisdiction. Users must adhere to KYC and AML standards and requirements.
+

--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@ description: >-
 
 # KiiChain Documentation
 
-[![GitHub stars](https://img.shields.io/github/stars/KiiChain/kiichain-docs?style=social)](https://github.com/KiiChain/kiichain-docs/stargazers)
-[![GitHub forks](https://img.shields.io/github/forks/KiiChain/kiichain-docs?style=social)](https://github.com/KiiChain/kiichain-docs/network/members)
-[![GitHub issues](https://img.shields.io/github/issues/KiiChain/kiichain-docs)](https://github.com/KiiChain/kiichain-docs/issues)
-[![GitHub license](https://img.shields.io/github/license/KiiChain/kiichain-docs)](./LICENSE)
+[![Stars](https://img.shields.io/github/stars/KiiChain/kiichain-docs?style=flat&logo=github)](https://github.com/KiiChain/kiichain-docs/stargazers) [![Forks](https://img.shields.io/github/forks/KiiChain/kiichain-docs?style
+
 
 # What is Kii?
 


### PR DESCRIPTION
Summary
This PR enhances the `README.md` by adding GitHub badges to provide quick insights into the repository’s activity and metadata.

Changes
- Added badges for:
  - ⭐ GitHub Stars
  - 🍴 GitHub Forks
  - 🐛 Open Issues
  - 📜 License

Motivation
Badges improve the discoverability and professionalism of the documentation by giving contributors and visitors instant visibility into repo stats.

Preview
Badges are displayed at the top of `README.md` under the title **KiiChain Documentation**.
