### PR TITLE
Fix docs license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,30 +6,34 @@ description: >-
 
 # KiiChain Documentation
 
-[![Stars](https://img.shields.io/github/stars/KiiChain/kiichain-docs?style=flat&logo=github)](https://github.com/KiiChain/kiichain-docs/stargazers) [![Forks](https://img.shields.io/github/forks/KiiChain/kiichain-docs?style
+[![Stars](https://img.shields.io/github/stars/KiiChain/kiichain-docs?style=flat&logo=github)](https://github.com/KiiChain/kiichain-docs/stargazers) 
+[![Forks](https://img.shields.io/github/forks/KiiChain/kiichain-docs?style=flat&logo=github)](https://github.com/KiiChain/kiichain-docs/forks)
 
+---
 
-# What is Kii?
-
-### What is Kii
+## What is Kii?
 
 Kii is an onchain FX desk powering global payments, trading and finance solutions in an easy-to-use platform designed for everyone. Users, businesses or builders can use Kii by signing up for an account or connecting to APIs. Kii differs from other traditional platforms by its hybrid approach of sourcing liquidity and maintaining balances onchain exposed to local currencies. Kii supports fiat swaps and payins/payouts via the pricing of local, non-dollar stablecoins and other tokenized real-world assets.
 
-### Hybrid Matching Engine
+## Hybrid Matching Engine
 
 At the core of Kii is a hybrid matching engine that is able to source onchain liquidity across any blockchain ecosystem while using centralized pricing to hedge and rebalance onchain positions. The result is an ultra-liquid layer that can operate 24/7 on certain pairs that only have liquidity during traditional business hours.
 
-### Ramps
+## Ramps
 
 Kii has a full suite of on and off ramps enabling instant payins and payouts from its system. These ramps are both UI and API enabled with the ability to disperse directly or to third-party accounts while remaining 100% compliant.
 
-### Connect to APIs
+## Connect to APIs
 
 Kii has developed a suite of APIs that embed all centralized and decentralized functionalities into a single set of APIs that any application can use. For more information on the APIs, visit:
 
 * [Kii APIs](https://docs.kiiglobal.io/docs/connect-to-kiiex/connect-to-kiiex-apis)
 
-### KYC / AML
+## KYC / AML
 
 Kii complies fully with regulations in each jurisdiction. Users must adhere to KYC and AML standards and requirements.
+
+---
+
+📄 [LICENSE](https://github.com/KiiChain/kiichain-docs/blob/main/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ description: >-
   onchain FX trading for cross-border payments.
 ---
 
+# KiiChain Documentation
+
+[![GitHub stars](https://img.shields.io/github/stars/KiiChain/kiichain-docs?style=social)](https://github.com/KiiChain/kiichain-docs/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/KiiChain/kiichain-docs?style=social)](https://github.com/KiiChain/kiichain-docs/network/members)
+[![GitHub issues](https://img.shields.io/github/issues/KiiChain/kiichain-docs)](https://github.com/KiiChain/kiichain-docs/issues)
+[![GitHub license](https://img.shields.io/github/license/KiiChain/kiichain-docs)](./LICENSE)
+
 # What is Kii?
 
 ### What is Kii
@@ -27,3 +34,4 @@ Kii has developed a suite of APIs that embed all centralized and decentralized f
 ### KYC / AML
 
 Kii complies fully with regulations in each jurisdiction. Users must adhere to KYC and AML standards and requirements.
+

--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@ description: >-
 
 # KiiChain Documentation
 
-[![GitHub stars](https://img.shields.io/github/stars/KiiChain/kiichain-docs?style=social)](https://github.com/KiiChain/kiichain-docs/stargazers)
-[![GitHub forks](https://img.shields.io/github/forks/KiiChain/kiichain-docs?style=social)](https://github.com/KiiChain/kiichain-docs/network/members)
-[![GitHub issues](https://img.shields.io/github/issues/KiiChain/kiichain-docs)](https://github.com/KiiChain/kiichain-docs/issues)
-[![GitHub license](https://img.shields.io/github/license/KiiChain/kiichain-docs)](./LICENSE)
+[![Stars](https://img.shields.io/github/stars/KiiChain/kiichain-docs?style=flat&logo=github)](https://github.com/KiiChain/kiichain-docs/stargazers) [![Forks](https://img.shields.io/github/forks/KiiChain/kiichain-docs?style
+
 
 # What is Kii?
 


### PR DESCRIPTION
- Fixed heading hierarchy (only one H1 at the top)
- Updated LICENSE link to absolute GitHub URL
