### PR TITLE
[docs] Fix typo on Roadmap documentation

### DIFF
--- a/learn/kiichain/roadmap.md
+++ b/learn/kiichain/roadmap.md
@@ -40,7 +40,7 @@ Q1 & Q2:&#x20;
 
 Q3:&#x20;
 
-* Public sale, listing and mainnet.&#x20;
+* Public sale, listing, and mainnet launch.&#x20;
 * KIIDEX integration into KIIEX with listing of RWA products.&#x20;
 * PayFi module integration with mainnet.
 * Kii RWA protocol dApp that lets users manage cross-chain transfers of their RWA tokens.


### PR DESCRIPTION
# Description

Fix typo on roadmap documentation

## Type of change
-[ ] Public sale, listing and mainnet Change Public sale, listing, and mainnet launch.


- [x] Documentation (updates documentation on the project)

# How Has This Been Tested?

- [x] Haven been checked the documentation typo
