### PR TITLE
Fix link / learn/getting started/connect wallet to explorer app.md

### DIFF
--- a/learn/getting-started/README.md
+++ b/learn/getting-started/README.md
@@ -14,7 +14,7 @@ For on-chain activities, activations, airdrops and more, join our open testnet h
 
 ### Get a wallet in Testnet
 
-Testnet Oro supports wallet connections with EVM and Cosmos based wallets like MetaMask and Keplr . To set up a wallet, make sure you have the MetaMask or Keplr wallet extension downloaded in your web browser. MetaMask supports extension downloads for the following web browsers: Chrome, Firefox, Brave, Edge and Opera. Kelpr supports wallets in Chrome, Firefox and Edge.
+Testnet Oro supports wallet connections with EVM and Cosmos based wallets like MetaMask and Keplr. To set up a wallet, make sure you have the MetaMask or Keplr wallet extension downloaded in your web browser. MetaMask supports extension downloads for the following web browsers: Chrome, Firefox, Brave, Edge and Opera. Kelpr supports wallets in Chrome, Firefox and Edge.
 
 For further explanation of how to set up your wallet, follow the steps [here](https://docs.kiiglobal.io/docs/getting-started/set-up-a-web-wallet) or connect your testnet wallet to our explorer app automatically by following the steps [here](https://docs.kiiglobal.io/docs/getting-started/connect-wallet-to-explorer-app).
 

--- a/learn/getting-started/connect-wallet-to-explorer-app.md
+++ b/learn/getting-started/connect-wallet-to-explorer-app.md
@@ -16,7 +16,7 @@ Go to [https://explorer.kiichain.io](https://app.kiiglobal.io/) and make sure yo
 
 <figure><img src="../../.gitbook/assets/Screenshot 2025-01-06 at 1.07.24 PM.png" alt="" width="365"><figcaption></figcaption></figure>
 
-For setting up a web wallet, see "[Set Up a Web Wallet](https://docs.kiiglobal.io/docs/getting-started/set-up-a-web-wallet)[t](https://docs.kiiglobal.io/docs/getting-started/set-up-a-web-wallet)".  Once your wallet has been created, you can link it to the explorer app by clicking the wallet icon in the top right corner.&#x20;
+For setting up a web wallet, see "[Set Up a Web Wallet](https://docs.kiiglobal.io/docs/getting-started/set-up-a-web-wallet)".  Once your wallet has been created, you can link it to the explorer app by clicking the wallet icon in the top right corner.&#x20;
 
 <figure><img src="../../.gitbook/assets/Screenshot 2025-01-06 at 1.08.35 PM.png" alt="" width="423"><figcaption></figcaption></figure>
 

--- a/learn/getting-started/download-a-mobile-wallet.md
+++ b/learn/getting-started/download-a-mobile-wallet.md
@@ -7,7 +7,7 @@ hidden: true
 
 ### **Download Kii Mobile on the App Store or Google Play**
 
-Mobile wallets are currently in deployment mode for Testnet Oro. Mobile wallets are available on the App Store and Google Play for users who would like to have access to the basic functions of the chain. Within the mobile wallet, users can login via email or manage their 24 set word keys.&#x20;
+Mobile wallets are currently in deployment mode for Testnet Oro, and available on the App Store and Google Play for users who would like to have access to the basic functions of the chain. Within the mobile wallet, users can login via email or manage their 24‑word seed phrase.&#x20;
 
 Apple Store: [https://apps.apple.com/us/app/kii-mobile/id6474740411](https://apps.apple.com/us/app/kii-mobile/id6474740411)
 


### PR DESCRIPTION
# Description

there's double link in "set up a wallet" link, causing double link but its a different link and causing typo in the link

## Type of change

Please delete options that are not relevant.
- [x] Documentation (updates documentation on the project)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
