### PR TITLE
docs: main/build-on-kiichain/developer-tools/deploy-a-smart-contract.md

### DIFF
--- a/build-on-kiichain/developer-tools/deploy-a-smart-contract.md
+++ b/build-on-kiichain/developer-tools/deploy-a-smart-contract.md
@@ -109,7 +109,7 @@ In the “Deploy and Run Transactions” section, move to the Environment and se
 
 #### 4. Deploy Smart contract
 
-Select the smart contract to be deployed and write the Constructor parameters is Remix detects them
+Select the smart contract to be deployed and write the Constructor parameters if Remix detects them
 
 <figure><img src="../../.gitbook/assets/image (19) (1).png" alt="" width="563"><figcaption></figcaption></figure>
 


### PR DESCRIPTION
# Description

fix typo from 
Select the smart contract to be deployed and write the Constructor parameters is Remix detects them 
to 
Select the smart contract to be deployed and write the Constructor parameters if Remix detects them

i change is to if because if not replaced it will make the reader a little confused when reading the docs


