### PR TITLE
add documentation for external modules (EVM, ERC20, FeeMarket, RateLimiter)

### DIFF
--- a/docs/modules/erc20.md
+++ b/docs/modules/erc20.md
@@ -1,0 +1,23 @@
+# ERC20 Module
+
+The **ERC20 module** provides compatibility for the Ethereum ERC20 token standard within KiiChain. It enables token minting, transfer, and conversion between Cosmos native assets and ERC20 tokens.
+
+## Overview
+This module bridges Cosmos and EVM token models, allowing both ERC20 and Cosmos-based applications to operate seamlessly within the same chain.
+
+## Key Features
+- Supports ERC20 token mint, burn, and transfer.
+- Converts tokens between EVM and Cosmos formats.
+- Ensures 1:1 token representation across both environments.
+- Integrates with bank and EVM modules.
+
+## Main Functions
+- **ConvertERC20** — Converts ERC20 tokens to native format.
+- **ConvertCoin** — Converts Cosmos coins to ERC20 format.
+- **RegisterTokenPair** — Registers cross-representation token pairs.
+
+## References
+- [Evmos ERC20 Module](https://docs.evmos.org/modules/erc20/)
+- [ERC20 Standard](https://eips.ethereum.org/EIPS/eip-20)
+- Referenced in `go.mod`
+- 

--- a/docs/modules/erc20.md
+++ b/docs/modules/erc20.md
@@ -20,4 +20,3 @@ This module bridges Cosmos and EVM token models, allowing both ERC20 and Cosmos-
 - [Evmos ERC20 Module](https://docs.evmos.org/modules/erc20/)
 - [ERC20 Standard](https://eips.ethereum.org/EIPS/eip-20)
 - Referenced in `go.mod`
-- 

--- a/docs/modules/evm.md
+++ b/docs/modules/evm.md
@@ -1,0 +1,21 @@
+# EVM Module
+
+The **EVM module** brings full Ethereum Virtual Machine (EVM) compatibility to KiiChain, enabling the execution of Solidity-based smart contracts directly on the network.
+
+## Overview
+By integrating EVM functionality, KiiChain allows developers to deploy, call, and interact with Ethereum-style contracts while benefiting from Cosmos SDK’s modular and efficient architecture.
+
+## Key Features
+- Supports Solidity smart contracts.
+- Compatible with Ethereum development tools (Remix, MetaMask, Hardhat).
+- Enables interoperability between EVM and native Cosmos modules.
+- Provides a gas model aligned with the Cosmos SDK fee system.
+
+## Main Functions
+- Developers interact with the EVM module using Ethereum-compatible JSON-RPC endpoints and Cosmos SDK messages such as `MsgEthereumTx`. Contract deployment and calls follow standard Ethereum procedures.
+
+## References
+- [Evmos EVM Module](https://docs.evmos.org/)
+- [Ethereum EVM Overview](https://ethereum.org/en/developers/docs/evm/)
+- Referenced in `go.mod`
+- 

--- a/docs/modules/evm.md
+++ b/docs/modules/evm.md
@@ -18,4 +18,3 @@ By integrating EVM functionality, KiiChain allows developers to deploy, call, an
 - [Evmos EVM Module](https://docs.evmos.org/)
 - [Ethereum EVM Overview](https://ethereum.org/en/developers/docs/evm/)
 - Referenced in `go.mod`
-- 

--- a/docs/modules/feemarket.md
+++ b/docs/modules/feemarket.md
@@ -1,0 +1,23 @@
+# FeeMarket Module
+
+The **FeeMarket module** introduces a dynamic gas fee mechanism inspired by Ethereum’s EIP-1559, enabling better transaction prioritization and fee predictability.
+
+## Overview
+This module provides a base fee adjustment mechanism that balances demand and supply for block space, improving user experience and preventing spam.
+
+## Key Features
+- Implements base fee adjustment per block.
+- Supports priority fees (tips) for faster inclusion.
+- Integrates with the EVM module’s gas pricing.
+- Ensures predictable transaction costs.
+
+## Main Functions
+- **GetBaseFee** — Retrieves current base fee.
+- **CalculateNextBaseFee** — Determines base fee for the next block.
+- **SetBaseFee** — Updates fee parameters in governance.
+
+## References
+- [EIP-1559 Specification](https://eips.ethereum.org/EIPS/eip-1559)
+- [Evmos FeeMarket Module](https://docs.evmos.org/modules/feemarket/)
+- Referenced in `go.mod`
+- 

--- a/docs/modules/feemarket.md
+++ b/docs/modules/feemarket.md
@@ -20,4 +20,3 @@ This module provides a base fee adjustment mechanism that balances demand and su
 - [EIP-1559 Specification](https://eips.ethereum.org/EIPS/eip-1559)
 - [Evmos FeeMarket Module](https://docs.evmos.org/modules/feemarket/)
 - Referenced in `go.mod`
-- 

--- a/docs/modules/rate-limiter.md
+++ b/docs/modules/rate-limiter.md
@@ -1,0 +1,22 @@
+# Rate Limiter Module
+
+The **Rate Limiter module** enforces transfer rate limits on specific token denominations or channels to enhance security and maintain chain stability.
+
+## Overview
+This module restricts cross-chain or inter-module transfers based on predefined thresholds to prevent sudden liquidity drains or bridge exploitation.
+
+## Key Features
+- Configurable per-token or per-channel transfer limits.
+- Supports both inbound and outbound rate control.
+- Integrates with IBC and governance parameters.
+- Provides query endpoints for monitoring limit usage.
+
+## Main Functions
+- **SetRateLimit** — Defines a rate limit for a token or channel.
+- **RemoveRateLimit** — Deletes existing rate configurations.
+- **QueryRateLimit** — Fetches limit data and usage status.
+
+## References
+- [Rate Limiter Overview (Stride)](https://github.com/Stride-Labs/ibc-rate-limiting)
+- Referenced in `go.mod`
+- 

--- a/docs/modules/rate-limiter.md
+++ b/docs/modules/rate-limiter.md
@@ -19,4 +19,3 @@ This module restricts cross-chain or inter-module transfers based on predefined 
 ## References
 - [Rate Limiter Overview (Stride)](https://github.com/Stride-Labs/ibc-rate-limiting)
 - Referenced in `go.mod`
-- 


### PR DESCRIPTION
### Description
Added missing documentation for external modules as requested in issue #18.

### Modules documented
- EVM
- ERC20
- FeeMarket
- RateLimiter

### Related issue
Related #18
