### PR TITLE
Add validate-the-network/Troubleshooting.md

### DIFF
--- a/validate-the-network/Troubleshooting.md
+++ b/validate-the-network/Troubleshooting.md
@@ -1,0 +1,98 @@
+# 🧩 Troubleshooting for KiiChain Validator Nodes
+
+This document helps KiiChain validators troubleshoot common node issues, such as sync failures, unstable peer connections, or configuration errors.
+
+---
+
+## ⚙️ Node Unable to Sync
+
+### Symptoms
+- Node freezes at a specific block height.
+- Log messages such as: ERR failed to fetch block or state sync failed: no suitable peers
+
+- ### Solution
+1. Ensure a stable internet connection and an open RPC port (default `26657`).
+2. Delete old node data:
+```bash
+kiichaind unsafe-reset-all
+
+3.Add persistent peers to the config/config.toml file: persistent_peers = "peer1@1.2.3.4:26656,peer2@5.6.7.8:26656"
+
+(Use the peer list from the official documentation or the Discord community.)
+
+Restart the node:
+
+systemctl restart kiichaind
+
+
+Node Stuck in State Sync
+
+Symptom
+
+Sync stops even though the status is StateSync: true.
+
+Solution
+
+Ensure the trust_height and trust_hash parameters are valid (use a block from the previous hour).
+
+Try temporarily disabling state_sync and allowing full sync:
+
+[statesync]enable = false
+
+Restart the node to force a full sync.
+
+No Peers Connected
+
+Symptoms
+
+Log shows:
+
+No peers connected
+
+The node is not receiving new blocks.
+
+
+Solution
+
+Ensure the P2P port (26656) is open and not blocked by the firewall.
+
+Check the config/config.toml file:
+
+seeds and persistent_peers are not empty.
+
+addr_book_strict = false for testing mode.
+
+Add public peers manually: kiichaind unsafe-reset-peers
+
+How to View Node Logs
+
+To view node activity and errors:
+
+journalctl -fu kiichaind -o cat
+
+Or just the last 50 lines:
+
+journalctl -u kiichaind -n 50 --no-pager
+
+⚠️ Common Configuration Errors
+
+ComponentsCommon ErrorsSolutionconfig.tomlRPC or P2P port is wrongMake sure default: 26656 (P2P), 26657 (RPC)app.tomlMinimum gas price is emptySet minimum-gas-prices = "0.025ukii"client.tomlChain ID is not appropriateUse kiichain-testnet-1 or appropriate active networkDataCache is not clearedRun unsafe-reset-all before resync
+General Tips
+
+Run the node with systemctl enable kiichaind to automatically start on reboot.
+
+Use monitoring tools like Grafana + Prometheus if the validator is active.
+
+Securely back up priv_validator_key.json.
+
+Always update the binary version from official releases.
+
+💬 Need Help?
+
+If you're still having trouble:
+
+Open a new issue on GitHub: Issues → New issue → Validator Troubleshooting
+
+Or join the official KiiChain Discord community.
+Last updated: October 2025
+Contributor: @Pilex3173

--- a/validate-the-network/Troubleshooting.md
+++ b/validate-the-network/Troubleshooting.md
@@ -1,4 +1,4 @@
-# ðŸ§© Troubleshooting for KiiChain Validator Nodes
+#🧩Troubleshooting for KiiChain Validator Nodes
 
 This document helps **KiiChain validators** troubleshoot common node issues â€” such as sync failures, unstable peer connections, or configuration errors.
 

--- a/validate-the-network/Troubleshooting.md
+++ b/validate-the-network/Troubleshooting.md
@@ -1,98 +1,123 @@
-# 🧩 Troubleshooting for KiiChain Validator Nodes
+# ðŸ§© Troubleshooting for KiiChain Validator Nodes
 
-This document helps KiiChain validators troubleshoot common node issues, such as sync failures, unstable peer connections, or configuration errors.
+This document helps **KiiChain validators** troubleshoot common node issues â€” such as sync failures, unstable peer connections, or configuration errors.
 
 ---
 
-## ⚙️ Node Unable to Sync
+## âš™ï¸ Node Unable to Sync
 
-### Symptoms
-- Node freezes at a specific block height.
-- Log messages such as: ERR failed to fetch block or state sync failed: no suitable peers
+### ðŸ§  Symptoms
+- Node freezes at a specific block height.  
+- Log messages such as:
+  ```
+  ERR failed to fetch block
+  state sync failed: no suitable peers
+  ```
 
-- ### Solution
-1. Ensure a stable internet connection and an open RPC port (default `26657`).
+### ðŸ› ï¸ Solution
+1. Ensure a stable internet connection and that the RPC port (default `26657`) is open.  
 2. Delete old node data:
-```bash
-kiichaind unsafe-reset-all
+   ```bash
+   kiichaind unsafe-reset-all
+   ```
+3. Add persistent peers in `config/config.toml`:
+   ```bash
+   persistent_peers = "peer1@1.2.3.4:26656,peer2@5.6.7.8:26656"
+   ```
+   > ðŸ’¡ Use the peer list from the official documentation or Discord community.
+4. Restart the node:
+   ```bash
+   systemctl restart kiichaind
+   ```
 
-3.Add persistent peers to the config/config.toml file: persistent_peers = "peer1@1.2.3.4:26656,peer2@5.6.7.8:26656"
+---
 
-(Use the peer list from the official documentation or the Discord community.)
+## ðŸ” Node Stuck in State Sync
 
-Restart the node:
+### ðŸ§  Symptom
+Sync stops even though the status is `StateSync: true`.
 
-systemctl restart kiichaind
+### ðŸ› ï¸ Solution
+1. Ensure the `trust_height` and `trust_hash` parameters are valid (use a block from the previous hour).  
+2. Temporarily disable state sync to allow a full sync:
+   ```bash
+   [statesync]
+   enable = false
+   ```
+3. Restart the node to force full synchronization.
 
+---
 
-Node Stuck in State Sync
+## ðŸŒ No Peers Connected
 
-Symptom
-
-Sync stops even though the status is StateSync: true.
-
-Solution
-
-Ensure the trust_height and trust_hash parameters are valid (use a block from the previous hour).
-
-Try temporarily disabling state_sync and allowing full sync:
-
-[statesync]enable = false
-
-Restart the node to force a full sync.
-
-No Peers Connected
-
-Symptoms
-
-Log shows:
-
+### ðŸ§  Symptoms
+Logs show:
+```
 No peers connected
-
+```
 The node is not receiving new blocks.
 
+### ðŸ› ï¸ Solution
+1. Ensure the P2P port (`26656`) is open and not blocked by a firewall.  
+2. Check `config/config.toml`:
+   - `seeds` and `persistent_peers` are not empty.  
+   - `addr_book_strict = false` (recommended for testing mode).  
+3. Add public peers manually:
+   ```bash
+   kiichaind unsafe-reset-peers
+   ```
 
-Solution
+---
 
-Ensure the P2P port (26656) is open and not blocked by the firewall.
+## ðŸ“œ How to View Node Logs
 
-Check the config/config.toml file:
-
-seeds and persistent_peers are not empty.
-
-addr_book_strict = false for testing mode.
-
-Add public peers manually: kiichaind unsafe-reset-peers
-
-How to View Node Logs
-
-To view node activity and errors:
-
+To view node activity and errors in real time:
+```bash
 journalctl -fu kiichaind -o cat
+```
 
-Or just the last 50 lines:
-
+To view only the last 50 lines:
+```bash
 journalctl -u kiichaind -n 50 --no-pager
+```
 
-⚠️ Common Configuration Errors
+---
 
-ComponentsCommon ErrorsSolutionconfig.tomlRPC or P2P port is wrongMake sure default: 26656 (P2P), 26657 (RPC)app.tomlMinimum gas price is emptySet minimum-gas-prices = "0.025ukii"client.tomlChain ID is not appropriateUse kiichain-testnet-1 or appropriate active networkDataCache is not clearedRun unsafe-reset-all before resync
-General Tips
+## âš ï¸ Common Configuration Errors
 
-Run the node with systemctl enable kiichaind to automatically start on reboot.
+| Component       | Common Error                        | Solution |
+|-----------------|--------------------------------------|-----------|
+| `config.toml`   | RPC or P2P port is wrong             | Use defaults: 26656 (P2P), 26657 (RPC) |
+| `app.toml`      | Minimum gas price is empty           | Set `minimum-gas-prices = "0.025ukii"` |
+| `client.toml`   | Wrong chain ID                       | Use `kiichain-testnet-1` or the current active network |
+| Data cache      | Not cleared before resync            | Run `kiichaind unsafe-reset-all` before resync |
 
-Use monitoring tools like Grafana + Prometheus if the validator is active.
+---
 
-Securely back up priv_validator_key.json.
+## ðŸ’¡ General Tips
 
-Always update the binary version from official releases.
+- Run the node with:
+  ```bash
+  systemctl enable kiichaind
+  ```
+  to automatically start it on system reboot.
 
-💬 Need Help?
+- Use **Grafana + Prometheus** for monitoring validator performance.  
+- Securely back up your `priv_validator_key.json`.  
+- Always update your binary from the official releases.
+
+---
+
+## ðŸ’¬ Need Help?
 
 If you're still having trouble:
 
-Open a new issue on GitHub: Issues → New issue → Validator Troubleshooting
+- **Open a new issue on GitHub:**  
+  `Issues â†’ New issue â†’ Validator Troubleshooting`
 
-Or join the official KiiChain Discord community.
-Last updated: October 2025
-Contributor: @Pilex3173
+- **Join the official KiiChain Discord** for community support.
+
+---
+
+_Last updated: October 2025_  
+**Contributor:** @Pilex3173

--- a/validate-the-network/Troubleshooting.md
+++ b/validate-the-network/Troubleshooting.md
@@ -1,12 +1,12 @@
-#🧩Troubleshooting for KiiChain Validator Nodes
+🧩Troubleshooting for KiiChain Validator Nodes
 
 This document helps **KiiChain validators** troubleshoot common node issues â€” such as sync failures, unstable peer connections, or configuration errors.
 
 ---
 
-## âš™ï¸ Node Unable to Sync
+⚙️Node Unable to Sync
 
-### ðŸ§  Symptoms
+🧠 Symptoms
 - Node freezes at a specific block height.  
 - Log messages such as:
   ```
@@ -14,7 +14,7 @@ This document helps **KiiChain validators** troubleshoot common node issues â�
   state sync failed: no suitable peers
   ```
 
-### ðŸ› ï¸ Solution
+🛠️ Solution
 1. Ensure a stable internet connection and that the RPC port (default `26657`) is open.  
 2. Delete old node data:
    ```bash
@@ -24,7 +24,7 @@ This document helps **KiiChain validators** troubleshoot common node issues â�
    ```bash
    persistent_peers = "peer1@1.2.3.4:26656,peer2@5.6.7.8:26656"
    ```
-   > ðŸ’¡ Use the peer list from the official documentation or Discord community.
+   💡 Use the peer list from the official documentation or Discord community.
 4. Restart the node:
    ```bash
    systemctl restart kiichaind
@@ -32,12 +32,12 @@ This document helps **KiiChain validators** troubleshoot common node issues â�
 
 ---
 
-## ðŸ” Node Stuck in State Sync
+🔁 Node Stuck in State Sync
 
-### ðŸ§  Symptom
+🧠 Symptom
 Sync stops even though the status is `StateSync: true`.
 
-### ðŸ› ï¸ Solution
+🛠️ Solution
 1. Ensure the `trust_height` and `trust_hash` parameters are valid (use a block from the previous hour).  
 2. Temporarily disable state sync to allow a full sync:
    ```bash
@@ -48,16 +48,15 @@ Sync stops even though the status is `StateSync: true`.
 
 ---
 
-## ðŸŒ No Peers Connected
-
-### ðŸ§  Symptoms
+🌐 No Peers Connected
+🧠 Symptoms
 Logs show:
 ```
 No peers connected
 ```
 The node is not receiving new blocks.
 
-### ðŸ› ï¸ Solution
+🛠️ Solution
 1. Ensure the P2P port (`26656`) is open and not blocked by a firewall.  
 2. Check `config/config.toml`:
    - `seeds` and `persistent_peers` are not empty.  
@@ -69,7 +68,7 @@ The node is not receiving new blocks.
 
 ---
 
-## ðŸ“œ How to View Node Logs
+📜 How to View Node Logs
 
 To view node activity and errors in real time:
 ```bash
@@ -83,7 +82,7 @@ journalctl -u kiichaind -n 50 --no-pager
 
 ---
 
-## âš ï¸ Common Configuration Errors
+⚠️ Common Configuration Errors
 
 | Component       | Common Error                        | Solution |
 |-----------------|--------------------------------------|-----------|
@@ -94,7 +93,7 @@ journalctl -u kiichaind -n 50 --no-pager
 
 ---
 
-## ðŸ’¡ General Tips
+💡 General Tips
 
 - Run the node with:
   ```bash
@@ -108,7 +107,7 @@ journalctl -u kiichaind -n 50 --no-pager
 
 ---
 
-## ðŸ’¬ Need Help?
+💬 Need Help?
 
 If you're still having trouble:
 

--- a/validate-the-network/Troubleshooting.md
+++ b/validate-the-network/Troubleshooting.md
@@ -1,6 +1,6 @@
 🧩Troubleshooting for KiiChain Validator Nodes
 
-This document helps **KiiChain validators** troubleshoot common node issues â€” such as sync failures, unstable peer connections, or configuration errors.
+This document helps **KiiChain validators** troubleshoot common node issues-” such as sync failures, unstable peer connections, or configuration errors.
 
 ---
 
@@ -18,7 +18,8 @@ This document helps **KiiChain validators** troubleshoot common node issues â�
 1. Ensure a stable internet connection and that the RPC port (default `26657`) is open.  
 2. Delete old node data:
    ```bash
-   kiichaind unsafe-reset-all
+   kiichaind tendermint unsafe-reset-all --keep-addr-book
+
    ```
 3. Add persistent peers in `config/config.toml`:
    ```bash


### PR DESCRIPTION
# Description

Added a validate-the-network/Troubleshooting.md file containing a guide for KiiChain node validators, including:

Solutions for failed state syncs

Peer disconnection issues

How to view logs and general configurations

Related Issues

#8 (Add “Troubleshooting” Section for Node Validators)
